### PR TITLE
Fix deployment error on vercel

### DIFF
--- a/lib/firebase_admin.js
+++ b/lib/firebase_admin.js
@@ -13,6 +13,10 @@ if (!serviceAccountJson) {
 let serviceAccount;
 try {
   serviceAccount = JSON.parse(serviceAccountJson);
+  // Replace escaped newlines in the private key with actual newlines so Firebase can parse the PEM correctly
+  if (serviceAccount.private_key) {
+    serviceAccount.private_key = serviceAccount.private_key.replace(/\\n/g, "\n");
+  }
 } catch (err) {
   throw new Error(
     "FIREBASE_SERVICE_ACCOUNT_KEYS contains invalid JSON. " +


### PR DESCRIPTION
Fix Firebase private key parsing by converting escaped newlines to actual newlines.

The `FIREBASE_SERVICE_ACCOUNT_KEYS` environment variable, when provided as a single-line JSON string, escapes newlines in the `private_key` field as `\\n`. While `JSON.parse` correctly handles this, the `firebase-admin` library expects the private key to be in a PEM format with literal newlines. This change ensures the `private_key` is correctly formatted for Firebase Admin SDK, resolving the "Invalid PEM formatted message" error during Vercel builds.